### PR TITLE
Add a script to force HDMI audio

### DIFF
--- a/PinToMindOS/src/modules/pintomindos/filesystem/home/pi/.fix_audio.sh
+++ b/PinToMindOS/src/modules/pintomindos/filesystem/home/pi/.fix_audio.sh
@@ -1,0 +1,6 @@
+# Hack to fix HDMI audio
+# Gets the index of the HDMI audio device, and sets it as the default
+# The HDMI audio device is called "MAI PCM i2s-hifi-0" in the list
+HDMIDEV=$(pacmd list-sinks | grep -e index -e "alsa.name = \"MAI" | grep MAI -B1 | head -n1 | cut -d " " -f6)
+pactl set-default-sink $HDMIDEV
+

--- a/PinToMindOS/src/modules/pintomindos/filesystem/home/pi/.xinitrc
+++ b/PinToMindOS/src/modules/pintomindos/filesystem/home/pi/.xinitrc
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 /home/pi/.adjust_video.sh
+/home/pi/.fix_audio.sh
 /home/pi/pintomind-player.AppImage &
 exec metacity
 

--- a/PinToMindOS/src/modules/pintomindos/start_chroot_script
+++ b/PinToMindOS/src/modules/pintomindos/start_chroot_script
@@ -29,11 +29,15 @@ fake-hwclock save
 
 # Install our minimal desktop environment
 apt-get install -y xserver-xorg libgles2-mesa libgles2-mesa-dev xorg-dev pciutils \
-	xinput metacity xinit fuse x11-xserver-utils plymouth plymouth-themes pix-plym-splash \
-        bluetooth bluez libbluetooth-dev libudev-dev libusb-1.0-0-dev libcap2-bin
+	xinput pulseaudio pulseaudio-utils metacity xinit fuse x11-xserver-utils plymouth \
+        plymouth-themes pix-plym-splash bluetooth bluez libbluetooth-dev libudev-dev \
+        libusb-1.0-0-dev libcap2-bin
 
 # Install Node, for the BLE bridge
-curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+apt update
 apt install -y nodejs
 
 # Use the Pi4's GPU instead of the general one (small performance boost)


### PR DESCRIPTION
Should hopefully fix HDMI audio. Supports both a regular Pi 4 and a Pi 400, and should work for both HDMI ports.
Also updates the NodeSource repo to suppress a warning.